### PR TITLE
Fix locked fields not re-enabling after step unlock

### DIFF
--- a/app.js
+++ b/app.js
@@ -623,7 +623,10 @@
             } else {
               el.removeAttribute('tabindex');
             }
-            if (el.dataset.lockPrevDisabled === 'false') {
+            const wasDisabled = el.dataset.lockPrevDisabled === 'true';
+            if (wasDisabled) {
+              el.disabled = true;
+            } else {
               el.removeAttribute('disabled');
             }
             el.removeAttribute('aria-disabled');


### PR DESCRIPTION
## Summary
- ensure step lock/unlock logic restores controls to their prior enabled state
- prevent quantity and acknowledgment fields from remaining disabled after completing previous steps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f9eac3fcc8321964b1f6c870fb985)