### PR TITLE
Fix help layout and restore step acknowledgements

### DIFF
--- a/app.js
+++ b/app.js
@@ -584,9 +584,7 @@
           stepState.completed[1] = false;
           stepState.available[2] = false;
           stepState.completed[2] = false;
-          ackPrivacy.checked = false;
-          ackTerms.checked = false;
-          syncPurchaserAccess();
+          resetAcknowledgements();
           hideReview();
           setFieldError(qtyEl, '');
           renderSummary(progressSummary);
@@ -699,6 +697,16 @@
       if (!unlocked) {
         Object.values(purchaser).forEach(el => setFieldError(el, ''));
       }
+    }
+
+    function resetAcknowledgements() {
+      ackPrivacy.checked = false;
+      ackTerms.checked = false;
+      ackPrivacy.disabled = false;
+      ackTerms.disabled = false;
+      ackPrivacy.removeAttribute('aria-disabled');
+      ackTerms.removeAttribute('aria-disabled');
+      syncPurchaserAccess();
     }
 
     function getFieldContainer(el) {
@@ -904,6 +912,9 @@
         stepState.available[i] = false;
         stepState.completed[i] = false;
         stepState.open[i] = false;
+      }
+      if (startIdx <= 1) {
+        resetAcknowledgements();
       }
       updateStepUI(startIdx);
     }
@@ -1234,6 +1245,7 @@ ${JSON.stringify(payload, null, 2)}
       stepState.available = [true, false, false];
       stepState.completed = [false, false, false];
       stepState.open = [true, false, false];
+      resetAcknowledgements();
       hideReview();
       hideErrors();
       hideLocationNotice();

--- a/styles.css
+++ b/styles.css
@@ -175,8 +175,7 @@
     .side ul{margin:10px 0 0 18px; color:var(--muted); font-size:13.5px}
     .side li{margin:6px 0}
     .eyebrow{display:inline-block; padding:3px 8px; border-radius:999px; background:rgba(11,15,25,.06); color:var(--muted); font-size:12px; font-weight:800; letter-spacing:.01em;}
-    .help-grid{display:grid; gap:12px; margin-top:10px;}
-    @media(min-width: 760px){.help-grid{grid-template-columns: 1fr 1fr;}}
+    .help-grid{display:grid; gap:12px; margin-top:10px; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));}
     .help-card{border:1px solid rgba(11,15,25,.12); border-radius:12px; padding:12px; background:rgba(11,15,25,.02);}
     .help-card .help-title{font-weight:900; margin-top:6px;}
     .help-links{margin:12px 0 0 16px; color:var(--muted); font-size:13.5px}


### PR DESCRIPTION
## Summary
- adjust the Need help sidebar grid to keep cards evenly aligned on desktop sizes
- add a reusable acknowledgement reset to keep Step 3 checkboxes interactive after changing earlier steps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69404d234cb88321bdcb53a8e4e48456)