### PR TITLE
Fictionalize government references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# BLM Forest Products Permits — Customer Flow Prototype (Static)
+# BWL Forest Products Permits — Customer Flow Prototype (Static)
 
-This repository is a static, front-end-only prototype demonstrating a customer flow for selecting a forest products permit (by **collection type → state → BLM office/district → product → quantity**) and collecting purchaser information. It **does not** process payments or generate permits.
+This repository is a static, front-end-only prototype demonstrating a customer flow for selecting a forest products permit (by **collection type → state → BWL office/district → product → quantity**) and collecting purchaser information. It **does not** process payments or generate permits.
 
 **Prototype behavior:** the “Continue to Pay.gov” action **prints a demo handoff payload** on-screen rather than redirecting to Pay.gov.
 
@@ -44,7 +44,7 @@ Open the URL printed by the command.
 ### Step 1 — Find available products
 1. Choose **What are you collecting?** (Fuelwood / Christmas trees / Mushrooms)
 2. Choose **State**
-3. Choose **BLM office / district** (typeahead combobox)
+3. Choose **BWL office / district** (typeahead combobox)
 
 ### Step 2 — Select product and quantity
 - Products display for the chosen office + type.

--- a/app.js
+++ b/app.js
@@ -413,7 +413,7 @@
         if (!model.ptype && !query) {
           div.textContent = 'Start typing to search offices.';
         } else if (model.ptype && !query) {
-          div.textContent = 'No BLM offices in this state offer that collection type online.';
+          div.textContent = 'No BWL offices in this state offer that collection type online.';
         } else {
           div.textContent = 'No matches. Try another search.';
         }
@@ -1069,8 +1069,8 @@
       if (id === 'ptypeGroup' && !model.ptype) return 'Select what you are collecting to view available permits.';
       if (id === 'state' && !val) return 'Choose a state to see offices in that area.';
       if (id === 'officeInput') {
-        if (!model.state) return 'Select a state to choose a BLM office.';
-        if (!model.officeId) return 'Select a BLM office from the list to continue.';
+        if (!model.state) return 'Select a state to choose a BWL office.';
+        if (!model.officeId) return 'Select a BWL office from the list to continue.';
       }
       if (id === 'qty') {
         const p = model.product;
@@ -1274,7 +1274,7 @@
           const parts = [];
           if (needsType) parts.push('select what you are collecting');
           if (needsState) parts.push('choose a state');
-          if (needsOffice) parts.push('pick a BLM office');
+          if (needsOffice) parts.push('pick a BWL office');
           lockNotes[1].textContent = `Complete step 1 to unlock.`;
         }
       }

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
   <a class="skip-link" href="#main">Skip to main content</a>
 
-  <section class="usa-banner" aria-label="Official website of the United States government">
+  <section class="usa-banner" aria-label="Official site of the United Regions of Elsewhere">
     <div class="wrap">
       <div class="inner">
         <div class="flag" aria-hidden="true">
@@ -27,19 +27,19 @@
             <rect width="76" height="53.85" fill="#3c3b6e"></rect>
           </svg>
         </div>
-        <div class="meta">An official website of the United States government</div>
+        <div class="meta">An official site of the United Regions of Elsewhere</div>
         <button type="button" id="bannerToggle" aria-expanded="false" aria-controls="bannerDetails">Here’s how you know</button>
       </div>
 
       <div class="usa-banner-details" id="bannerDetails">
         <div class="grid">
           <div class="info-card">
-            <div class="badge">.gov</div>
-            <div><strong>Official websites use .gov</strong>A .gov website belongs to an official U.S. government organization.</div>
+            <div class="badge">.ure</div>
+            <div><strong>Official sites use .ure</strong>A .ure site belongs to an official United Regions of Elsewhere organization.</div>
           </div>
           <div class="info-card">
             <div class="badge">🔒</div>
-            <div><strong>Secure .gov websites use HTTPS</strong>A lock or https:// means you’ve safely connected to the .gov website.</div>
+            <div><strong>Secure .ure sites use HTTPS</strong>A lock or https:// means you’ve safely connected to the .ure website.</div>
           </div>
         </div>
       </div>
@@ -53,10 +53,10 @@
   <div class="agency-bar" role="banner">
     <div class="wrap">
       <div class="row">
-        <div class="seal" aria-hidden="true">DOI</div>
-        <div class="agency-title" aria-label="U.S. Department of the Interior, Bureau of Land Management">
-          <div class="top">U.S. DEPARTMENT OF THE INTERIOR</div>
-          <div class="bot">BUREAU OF LAND MANAGEMENT</div>
+        <div class="seal" aria-hidden="true">MOT</div>
+        <div class="agency-title" aria-label="United Regions of Elsewhere Ministry of Outside Things, Bureau of Wandering Lands">
+          <div class="top">MINISTRY OF OUTSIDE THINGS</div>
+          <div class="bot">BUREAU OF WANDERING LANDS</div>
         </div>
         <div class="agency-actions">
           <a href="#need-help">Help</a>
@@ -70,8 +70,8 @@
     <div class="wrap">
       <section class="pagehead" aria-label="Page title and instructions">
         <h1>Online Forest Product Permits</h1>
-        <p>Get a permit to collect forest products on BLM-managed public lands in a few simple steps.</p>
-        <p class="federal-note">Permits obtained through this site are issued by the Bureau of Land Management.</p>
+        <p>Get a permit to collect forest products on Bureau of Wandering Lands-managed public lands in a few simple steps.</p>
+        <p class="federal-note">Permits obtained through this site are issued by the Bureau of Wandering Lands.</p>
 
         <div class="alert" role="status" aria-live="polite">
           <div class="icon" aria-hidden="true">i</div>
@@ -128,7 +128,7 @@
                 </div>
 
                 <div class="row">
-                  <label for="officeInput">BLM office / district <span aria-hidden="true" style="color:var(--danger)">*</span></label>
+                  <label for="officeInput">BWL office / district <span aria-hidden="true" style="color:var(--danger)">*</span></label>
                   <div class="hint">Start typing to filter. Use ↑/↓ to navigate; Enter to select.</div>
                   <div class="combo" id="officeCombo">
                     <input id="officeInput" type="text" autocomplete="off" placeholder="Type to search offices"
@@ -155,7 +155,7 @@
               <button class="step-toggle" type="button" aria-expanded="false">Step 2 · Select a product and quantity</button>
               <div class="step-status" id="status2">Locked</div>
             </div>
-            <div class="lock-note" id="step2LockNote">Select what you’re collecting, then choose a state and BLM office to unlock product selection.</div>
+            <div class="lock-note" id="step2LockNote">Select what you’re collecting, then choose a state and BWL office to unlock product selection.</div>
             <div class="step-body" style="display:none;">
               <div style="color:var(--muted); font-size:14px;">Choose one product, then enter your quantity to continue.</div>
 
@@ -197,9 +197,9 @@
 
 AUTHORITY: 30 U.S.C. 601 et seq.; 43 U.S.C. 1181a; and 43 CFR 5400 (as applicable).
 
-PRINCIPAL PURPOSE: The Bureau of Land Management (BLM) uses the information you provide to identify the permittee, document the authorization to remove vegetative materials from public lands, and administer and enforce permit terms.
+PRINCIPAL PURPOSE: The Bureau of Wandering Lands (BWL) uses the information you provide to identify the permittee, document the authorization to remove vegetative materials from public lands, and administer and enforce permit terms.
 
-ROUTINE USES: The BLM may disclose information consistent with published routine uses for the relevant system of records, and as otherwise authorized by law.
+ROUTINE USES: The BWL may disclose information consistent with published routine uses for the relevant system of records, and as otherwise authorized by law.
 
 EFFECT OF NOT PROVIDING INFORMATION: Providing the requested information is voluntary; however, failure to provide required information may prevent us from issuing your permit.
 </div>
@@ -319,7 +319,7 @@ Replace this demo text with the authoritative terms and conditions used by your 
       <p>
         If Pay.gov is down, wait 15 minutes and try again. You can also complete
         your purchase at a
-        <a href="https://www.blm.gov/office/national-office" target="_blank" rel="noopener">local BLM office</a>.
+        <a href="https://www.blm.gov/office/national-office" target="_blank" rel="noopener">local BWL office (external link)</a>.
       </p>
     </div>
 
@@ -348,7 +348,7 @@ Replace this demo text with the authoritative terms and conditions used by your 
           <p>
             This system does not support online permit lookup. If you cannot locate
             your permit or confirmation email, contact your
-            <a href="https://www.blm.gov/office/national-office" target="_blank" rel="noopener">local BLM office</a>
+            <a href="https://www.blm.gov/office/national-office" target="_blank" rel="noopener">local BWL office (external link)</a>
             during business hours. Staff can help locate your permit using your
             <strong>name and email address</strong>.
           </p>
@@ -372,7 +372,7 @@ Replace this demo text with the authoritative terms and conditions used by your 
         <div class="help-subaccordion-body">
           <p>
             If you believe you were charged more than once, contact your
-            <a href="https://www.blm.gov/office/national-office" target="_blank" rel="noopener">local BLM office</a>
+            <a href="https://www.blm.gov/office/national-office" target="_blank" rel="noopener">local BWL office (external link)</a>
             during business hours. Be prepared to provide your name, email address,
             and any payment confirmation information you received.
           </p>
@@ -390,7 +390,7 @@ Replace this demo text with the authoritative terms and conditions used by your 
           </ul>
           <p>
             If you are still unable to access your permit, contact your
-            <a href="https://www.blm.gov/office/national-office" target="_blank" rel="noopener">local BLM office</a>.
+            <a href="https://www.blm.gov/office/national-office" target="_blank" rel="noopener">local BWL office (external link)</a>.
           </p>
         </div>
       </details>
@@ -402,7 +402,7 @@ Replace this demo text with the authoritative terms and conditions used by your 
     <div class="help-card">
       <div class="eyebrow">Selecting products and availability</div>
       <p>
-        Only BLM offices that offer online permits for the collection type you
+        Only BWL offices that offer online permits for the collection type you
         selected are shown. If an office does not appear, it does not currently
         offer online permits for that collection type. Availability may change
         seasonally.
@@ -414,7 +414,7 @@ Replace this demo text with the authoritative terms and conditions used by your 
       <p>
         For maps, collection area restrictions, seasonal closures, or in-person
         payment options, contact your
-        <a href="https://www.blm.gov/office/national-office" target="_blank" rel="noopener">local BLM office</a>
+        <a href="https://www.blm.gov/office/national-office" target="_blank" rel="noopener">local BWL office (external link)</a>
         during regular business hours.
       </p>
     </div>
@@ -427,13 +427,13 @@ Replace this demo text with the authoritative terms and conditions used by your 
 
   <footer>
     <div class="wrap">
-      <div><strong>forestproducts.blm.gov</strong> — Prototype</div>
+      <div><strong>forestproducts.bwl.ure</strong> — Prototype</div>
       <div class="footer-links" aria-label="Footer links">
-        <a href="https://www.doi.gov/" target="_blank" rel="noopener">Department of the Interior</a>
-        <a href="https://www.doi.gov/about" target="_blank" rel="noopener">About DOI.gov</a>
-        <a href="https://www.doi.gov/pmb/eeo/no-fear-act" target="_blank" rel="noopener">No FEAR Act data</a>
-        <a href="https://www.doioig.gov/" target="_blank" rel="noopener">Office of Inspector General</a>
-        <a href="https://www.usa.gov/" target="_blank" rel="noopener">USA.gov</a>
+        <a href="https://www.doi.gov/" target="_blank" rel="noopener">Ministry of Outside Things (links to doi.gov)</a>
+        <a href="https://www.doi.gov/about" target="_blank" rel="noopener">About the MOT (external)</a>
+        <a href="https://www.doi.gov/pmb/eeo/no-fear-act" target="_blank" rel="noopener">No FEAR Act data (external DOI resource)</a>
+        <a href="https://www.doioig.gov/" target="_blank" rel="noopener">Office of Inspiring Guidance (links to doioig.gov)</a>
+        <a href="https://www.usa.gov/" target="_blank" rel="noopener">URE.gov portal (links to USA.gov)</a>
       </div>
       <div class="smallprint">Data shown is representative demo content.</div>
     </div>

--- a/products.json
+++ b/products.json
@@ -3,17 +3,29 @@
     "name": "Alaska",
     "description": "Seasonal fire and travel conditions change quickly in Alaska. Please review local access notices before your trip.",
     "attachments": [
-      { "label": "Alaska travel advisory (PDF)", "url": "#" },
-      { "label": "Statewide fire restrictions", "url": "#" }
+      {
+        "label": "Alaska travel advisory (PDF)",
+        "url": "#"
+      },
+      {
+        "label": "Statewide fire restrictions",
+        "url": "#"
+      }
     ],
     "offices": [
       {
         "id": "AK-ANCH",
-        "name": "Anchorage Field Office",
+        "name": "Anchorage Aurora Outpost",
         "description": "Anchorage area permits may require weekend travel restrictions during breakup season.",
         "attachments": [
-          { "label": "Anchorage access map", "url": "#" },
-          { "label": "Anchorage seasonal bulletin", "url": "#" }
+          {
+            "label": "Anchorage access map",
+            "url": "#"
+          },
+          {
+            "label": "Anchorage seasonal bulletin",
+            "url": "#"
+          }
         ],
         "products": {
           "fuelwood": [
@@ -138,14 +150,13 @@
       },
       {
         "id": "AK-FAIR",
-        "name": "Fairbanks District Office",
+        "name": "Fairbanks Frost District",
         "description": "Online permits from this office are temporarily unavailable. Contact the office for alternatives.",
         "products": {}
       },
-
       {
         "id": "AK-JUN",
-        "name": "Juneau Field Office",
+        "name": "Juneau Harbor Outpost",
         "products": {
           "fuelwood": [
             {
@@ -266,7 +277,7 @@
     "offices": [
       {
         "id": "AZ-STRIP",
-        "name": "Arizona Strip Field Office",
+        "name": "Arizona Strip Sunspan Outpost",
         "products": {
           "fuelwood": [
             {
@@ -386,7 +397,7 @@
       },
       {
         "id": "AZ-GILA",
-        "name": "Gila District Office",
+        "name": "Gila Ripple District",
         "products": {
           "fuelwood": [
             {
@@ -494,7 +505,7 @@
       },
       {
         "id": "AZ-YUMA",
-        "name": "Yuma Field Office",
+        "name": "Yuma Dune Outpost",
         "products": {
           "fuelwood": [
             {
@@ -599,7 +610,7 @@
     "offices": [
       {
         "id": "CA-BISH",
-        "name": "Bishop Field Office",
+        "name": "Bishop Basin Outpost",
         "products": {
           "fuelwood": [
             {
@@ -723,7 +734,7 @@
       },
       {
         "id": "CA-ARC",
-        "name": "Arcata Field Office",
+        "name": "Arcata Mist Outpost",
         "products": {
           "fuelwood": [
             {
@@ -847,7 +858,7 @@
       },
       {
         "id": "CA-RDD",
-        "name": "Redding Field Office",
+        "name": "Redding Riverbend Outpost",
         "products": {
           "fuelwood": [
             {
@@ -976,7 +987,7 @@
     "offices": [
       {
         "id": "CO-KREM",
-        "name": "Kremmling Field Office",
+        "name": "Kremmling Ridge Outpost",
         "products": {
           "fuelwood": [
             {
@@ -1100,7 +1111,7 @@
       },
       {
         "id": "CO-GUNN",
-        "name": "Gunnison Field Office",
+        "name": "Gunnison Gorge Outpost",
         "products": {
           "fuelwood": [
             {
@@ -1224,7 +1235,7 @@
       },
       {
         "id": "CO-GJ",
-        "name": "Grand Junction Field Office",
+        "name": "Grand Junction Mesa Outpost",
         "products": {
           "fuelwood": [
             {
@@ -1353,7 +1364,7 @@
     "offices": [
       {
         "id": "ID-POCA",
-        "name": "Pocatello Field Office",
+        "name": "Pocatello Prairie Outpost",
         "products": {
           "fuelwood": [
             {
@@ -1477,7 +1488,7 @@
       },
       {
         "id": "ID-BOIS",
-        "name": "Boise District Office",
+        "name": "Boise Bluff District",
         "products": {
           "fuelwood": [
             {
@@ -1601,7 +1612,7 @@
       },
       {
         "id": "ID-TWIN",
-        "name": "Twin Falls District Office",
+        "name": "Twin Falls Cascade District",
         "products": {
           "fuelwood": [
             {
@@ -1730,7 +1741,7 @@
     "offices": [
       {
         "id": "MT-MILES",
-        "name": "Miles City Field Office",
+        "name": "Miles City Meadow Outpost",
         "products": {
           "fuelwood": [
             {
@@ -1854,7 +1865,7 @@
       },
       {
         "id": "MT-HELENA",
-        "name": "Helena-Lewis and Clark Field Office",
+        "name": "Helena Discovery Outpost",
         "products": {
           "fuelwood": [
             {
@@ -1978,7 +1989,7 @@
       },
       {
         "id": "MT-BILL",
-        "name": "Billings Field Office",
+        "name": "Billings Bison Outpost",
         "products": {
           "fuelwood": [
             {
@@ -2107,7 +2118,7 @@
     "offices": [
       {
         "id": "33",
-        "name": "Carson City District",
+        "name": "Carson City Comet District",
         "products": {
           "fuelwood": [
             {
@@ -2231,7 +2242,7 @@
       },
       {
         "id": "NV-ELY",
-        "name": "Ely District Office",
+        "name": "Ely Echo District",
         "products": {
           "fuelwood": [
             {
@@ -2355,7 +2366,7 @@
       },
       {
         "id": "NV-LV",
-        "name": "Las Vegas Field Office",
+        "name": "Las Vegas Mirage Outpost",
         "products": {
           "fuelwood": [
             {
@@ -2484,7 +2495,7 @@
     "offices": [
       {
         "id": "NM-ROSW",
-        "name": "Roswell Field Office",
+        "name": "Roswell Orbit Outpost",
         "products": {
           "fuelwood": [
             {
@@ -2608,7 +2619,7 @@
       },
       {
         "id": "NM-TAOS",
-        "name": "Taos Field Office",
+        "name": "Taos Canyon Outpost",
         "products": {
           "fuelwood": [
             {
@@ -2732,7 +2743,7 @@
       },
       {
         "id": "NM-LAS",
-        "name": "Las Cruces District Office",
+        "name": "Las Cruces Suntrail District",
         "products": {
           "fuelwood": [
             {
@@ -2860,12 +2871,15 @@
     "name": "Oregon",
     "description": "Oregon offices may close areas during wet weather to protect roads. Check the latest notices before you plan your route.",
     "attachments": [
-      { "label": "Oregon seasonal road guidance", "url": "#" }
+      {
+        "label": "Oregon seasonal road guidance",
+        "url": "#"
+      }
     ],
     "offices": [
       {
         "id": "OR-SALEM",
-        "name": "Salem District Office",
+        "name": "Salem Starlight District",
         "products": {
           "fuelwood": [
             {
@@ -2989,10 +3003,13 @@
       },
       {
         "id": "OR-PRIN",
-        "name": "Prineville District Office",
+        "name": "Prineville Pinecone District",
         "description": "North Fork area requires self-issue access pass when snow gates are closed.",
         "attachments": [
-          { "label": "Prineville winter travel map", "url": "#" }
+          {
+            "label": "Prineville winter travel map",
+            "url": "#"
+          }
         ],
         "products": {
           "fuelwood": [
@@ -3117,7 +3134,7 @@
       },
       {
         "id": "OR-LAKE",
-        "name": "Lakeview District Office",
+        "name": "Lakeview Loon District",
         "products": {
           "fuelwood": [
             {
@@ -3246,7 +3263,7 @@
     "offices": [
       {
         "id": "UT-CCFO",
-        "name": "Cedar City Field Office",
+        "name": "Cedar City Cedarwind Outpost",
         "products": {
           "fuelwood": [
             {
@@ -3370,13 +3387,13 @@
       },
       {
         "id": "UT-STG",
-        "name": "St. George Field Office",
+        "name": "St. George Sandstone Outpost",
         "description": "Online permits are currently unavailable from this office. Please select another office.",
         "products": {}
       },
       {
         "id": "UT-MOAB",
-        "name": "Moab Field Office",
+        "name": "Moab Redrock Outpost",
         "products": {
           "fuelwood": [
             {
@@ -3505,7 +3522,7 @@
     "offices": [
       {
         "id": "WA-SPK",
-        "name": "Spokane District Office",
+        "name": "Spokane Spruce District",
         "products": {
           "fuelwood": [
             {
@@ -3629,7 +3646,7 @@
       },
       {
         "id": "WA-WEN",
-        "name": "Wenatchee Field Office",
+        "name": "Wenatchee Wildflower Outpost",
         "products": {
           "fuelwood": [
             {
@@ -3753,7 +3770,7 @@
       },
       {
         "id": "WA-VAN",
-        "name": "Vancouver Field Office",
+        "name": "Vancouver Evergreen Outpost",
         "products": {
           "fuelwood": [
             {
@@ -3882,7 +3899,7 @@
     "offices": [
       {
         "id": "WY-CASP",
-        "name": "Casper Field Office",
+        "name": "Casper Cloudvale Outpost",
         "products": {
           "fuelwood": [
             {
@@ -4006,7 +4023,7 @@
       },
       {
         "id": "WY-ROCK",
-        "name": "Rock Springs Field Office",
+        "name": "Rock Springs Starwell Outpost",
         "products": {
           "fuelwood": [
             {
@@ -4130,7 +4147,7 @@
       },
       {
         "id": "WY-WORL",
-        "name": "Worland Field Office",
+        "name": "Worland Wash Outpost",
         "products": {
           "fuelwood": [
             {

--- a/styles.css
+++ b/styles.css
@@ -31,7 +31,7 @@
     .skip-link{position:absolute; left:-999px; top:auto; width:1px; height:1px; overflow:hidden;}
     .skip-link:focus{left:16px; top:16px; width:auto; height:auto; padding:10px 12px; background:#000; color:#fff; border-radius:10px; z-index:9999;}
     .sr-only{position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); border:0;}
-    /* USA banner */
+    /* URE banner */
     .usa-banner{background:#f1f1f1; border-bottom:1px solid rgba(0,0,0,.12); font-size:13px;}
     .usa-banner .inner{display:flex; align-items:center; gap:10px; padding:9px 0;}
     .flag{width:18px; height:12px; border:1px solid rgba(0,0,0,.2); border-radius:2px; overflow:hidden}


### PR DESCRIPTION
## Summary
- replace real-world government labels with United Regions of Elsewhere equivalents across the UI
- update validation/help copy to reference Bureau of Wandering Lands and refreshed footer links
- retheme product catalog office names with lighthearted fictional outposts and districts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941bdf5745c83219fc72a9e1b78c950)