### PR TITLE
Fix dropdown visibility and update link colors

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,7 @@
       --field:#f7fbf5;
       --danger:#b42318;
       --ok:#0f6c3a;
+      --link:#0b63ce;
       --radius:14px;
       --max:1160px;
       --font: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
@@ -27,7 +28,7 @@ body{
         radial-gradient(700px 280px at 86% 10%, rgba(29,107,66,.08), transparent 60%),
         linear-gradient(180deg, #fff 0%, var(--bg) 62%);
     }
-    a{color:var(--brand); text-decoration:none}
+    a{color:var(--link); text-decoration:none}
     a:hover{text-decoration:underline}
     .wrap{max-width:var(--max); margin:0 auto; padding:0 18px}
     .skip-link{position:absolute; left:-999px; top:auto; width:1px; height:1px; overflow:hidden;}
@@ -73,7 +74,7 @@ body{
     main{padding:10px 0 46px}
     .layout{display:grid; gap:18px; align-items:start}
     @media(min-width: 980px){ .layout{grid-template-columns: minmax(0, 1.25fr) 340px; gap:26px; align-items:start} }
-.card{background:var(--card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:var(--shadow); padding:16px; position:relative; overflow:hidden;}
+.card{background:var(--card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:var(--shadow); padding:16px; position:relative; overflow:visible;}
 .card::before{content:""; position:absolute; inset:0; background:linear-gradient(145deg, rgba(247,251,245,.85), rgba(255,255,255,.92)); z-index:0;}
 .card > *{position:relative; z-index:1;}
     /* Stepper */
@@ -132,7 +133,7 @@ body{
     .agreements-list{display:grid; gap:10px;}
     .checkline{display:flex; gap:10px; font-weight:750; align-items:flex-start;}
     .checkline input{width:auto; margin-top:2px;}
-    .inline-link{border:0; background:none; color:var(--brand); font-weight:750; cursor:pointer; padding:0; margin-left:6px; text-decoration:underline;}
+    .inline-link{border:0; background:none; color:var(--link); font-weight:750; cursor:pointer; padding:0; margin-left:6px; text-decoration:underline;}
     .inline-link:hover{text-decoration:none;}
     /* Combobox */
     .combo{position:relative}
@@ -171,7 +172,7 @@ body{
     .desc{color:var(--ink); font-size:14px;}
     .rule-list{margin:6px 0 0 18px; color:var(--muted); font-size:13px; line-height:1.5}
     .docs{margin-top:10px; font-size:13px; color:var(--muted)}
-    .docs a{color:var(--brand)}
+    .docs a{color:var(--link)}
     .docs a:hover{text-decoration:underline}
     .location-note{margin-top:12px; border:1px solid rgba(29,107,66,.16); border-radius:14px; padding:12px; background:rgba(29,107,66,.04); box-shadow:0 10px 18px rgba(12,26,28,.05);}
     .location-note .title{font-weight:900; font-size:14px; display:flex; align-items:center; gap:8px;}


### PR DESCRIPTION
## Summary
- allow the office combo box dropdown to render above neighboring content instead of being clipped
- change anchor and inline link styling to use a blue link color

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694311e2708c8321b3933906c8fee678)