### PR TITLE
Remove progress summary and adjust acknowledgements layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -72,7 +72,6 @@
       document.getElementById('status3')
     ];
 
-    const progressSummary = document.getElementById('progressSummary');
     const locationNotice = document.getElementById('locationNotice');
     const reviewSummary = document.getElementById('reviewSummary');
     const reviewNotice = document.getElementById('reviewNotice');
@@ -672,41 +671,6 @@
       locationNotice.style.display = 'block';
     }
 
-    function renderSummary(el) {
-      const stateName = DATA[model.state]?.name || '';
-      const ptypeLabel = (PRODUCT_TYPES.find(t => t.id === model.ptype)?.label) || '';
-      const prod = model.product;
-      const qty = model.qty;
-      const { durationLabel, expirationLabel } = getValidityLabels(prod);
-      const docs = prod ? buildRequiredDocs(prod) : [];
-      const docLinks = (docs.length > 0) ? buildDocLinks(docs, { includePrefix: false }) : null;
-      if (docLinks) docLinks.classList.add('summary-docs');
-      el.innerHTML = '';
-      const entries = [
-        ['Selection', `${stateName || '—'} • ${model.officeName || '—'} • ${ptypeLabel || '—'}`],
-        ['Product', prod ? prod.name : '—'],
-        ['Quantity', qty ? `${qty} ${prod?.unit || ''}${qty === 1 ? '' : 's'}` : '—'],
-        ['Valid for', prod ? durationLabel : '—'],
-        ['Permit expires', prod ? expirationLabel : '—'],
-        ['Required documents', docLinks || '—']
-      ];
-      entries.forEach(([label, value], idx) => {
-        const k = document.createElement('div');
-        k.className = 'k';
-        if (idx > 0) k.style.marginTop = '8px';
-        k.textContent = label;
-        const v = document.createElement('div');
-        v.className = 'v';
-        if (value instanceof Node) {
-          v.appendChild(value);
-        } else {
-          v.textContent = value;
-        }
-        el.appendChild(k);
-        el.appendChild(v);
-      });
-    }
-
     function hideReview() {
       reviewSummary.style.display = 'none';
       reviewNotice.style.display = 'none';
@@ -882,7 +846,6 @@
         resetAcknowledgements();
         hideReview();
         setFieldError(qtyEl, '');
-        renderSummary(progressSummary);
         setOpenStep(1);
         qtyEl.focus();
         updateReviewActions();
@@ -1168,7 +1131,6 @@
       stepState.available[2] = false;
       stepState.completed[2] = false;
       stepState.open = [stepState.open[0], true, false];
-      renderSummary(progressSummary);
       hideReview();
       reviewSummary.style.display = 'none';
       reviewNotice.style.display = 'none';
@@ -1194,7 +1156,6 @@
       const ok = validateQty();
       stepState.completed[1] = ok;
       stepState.available[2] = ok;
-      renderSummary(progressSummary);
       if (openNext && ok) {
         setOpenStep(2);
       } else {
@@ -1245,7 +1206,6 @@
       if (!ok) {
         resetFollowingSteps(0);
         stepState.open = [true, false, false];
-        renderSummary(progressSummary);
         hideLocationNotice();
         productListEl.innerHTML = '';
         qtySection.style.display = 'none';
@@ -1254,7 +1214,6 @@
         return;
       }
 
-      renderSummary(progressSummary);
       renderProducts();
       setOpenStep(1);
       updateStepUI(1);
@@ -1274,7 +1233,6 @@
       setFieldError(stateEl, '');
       setFieldError(officeInput, '');
       syncSelectionAvailability();
-      renderSummary(progressSummary);
       updateReviewActions();
       persistState();
       attemptAdvanceFromStep1();
@@ -1330,7 +1288,6 @@
 
       hideErrors();
       stepState.completed[2] = true;
-      renderSummary(progressSummary);
       renderReviewSummary();
       reviewSummary.style.display = 'block';
       reviewNotice.style.display = 'flex';
@@ -1373,7 +1330,6 @@
       validateStep1();
       hideReview();
       hideLocationNotice();
-      renderSummary(progressSummary);
       syncSelectionAvailability();
       updateStepUI(0);
       updateReviewActions();
@@ -1478,7 +1434,6 @@
       stepState.completed[1] = ok;
       stepState.available[2] = ok;
       stepState.completed[2] = false;
-      renderSummary(progressSummary);
       hideReview();
       updateLockNotes();
       updateStepUI(model.step);
@@ -1587,16 +1542,6 @@
       handoff.scrollIntoView({ behavior:'smooth', block:'start' });
     });
 
-    document.querySelectorAll('[data-open-detail]').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        const target = document.querySelector(btn.dataset.openDetail);
-        if (target && target.tagName === 'DETAILS') {
-          target.open = true;
-          target.querySelector('summary')?.focus();
-        }
-      });
-    });
-
     resetAllBtn.addEventListener('click', () => {
       resetStateSelection();
       setProductType('');
@@ -1610,7 +1555,6 @@
       hideErrors();
       hideLocationNotice();
       clearAllFieldErrors();
-      renderSummary(progressSummary);
       syncSelectionAvailability();
       updateStepUI(0);
       updateReviewActions();
@@ -1622,7 +1566,6 @@
       syncSelectionAvailability();
       await loadProductData();
       populateUSStates(purchaser.AddrState);
-      renderSummary(progressSummary);
       restoreState();
       syncPurchaserAccess();
       updateReviewActions();

--- a/index.html
+++ b/index.html
@@ -97,8 +97,6 @@
 
           <div id="stepLiveRegion" class="sr-only" aria-live="polite"></div>
 
-          <div class="summary" id="progressSummary"></div>
-
           <!-- Step 1 -->
           <section id="step1" class="flow-step" aria-label="Step 1: Choose location">
             <div class="step-head">
@@ -185,9 +183,20 @@
             <div class="lock-note" id="step3LockNote">Choose a product and quantity to review agreements and enter purchaser information.</div>
             <div class="step-body" style="display:none;">
 
-              <details id="privacyDetail">
-                <summary>Privacy Act Notification</summary>
-                <div class="body">NOTICE: The Privacy Act of 1974 and applicable regulations require that you be furnished with the following information in connection with information collected for this permit purchase.
+              <div class="agreements" role="group" aria-label="Policy acknowledgements">
+                <div class="agreements-copy">
+                  <div class="eyebrow">Step 3</div>
+                  <div class="title">Review and accept</div>
+                  <p class="hint">Read the following summaries. You can open the full text before acknowledging.</p>
+                </div>
+                <div class="agreements-list">
+                  <div class="agreement-item">
+                    <label class="checkline"><input type="checkbox" id="ackPrivacy" />
+                      I understand how my information will be used (Privacy Act).
+                    </label>
+                    <details id="privacyDetail">
+                      <summary>Privacy Act Notification</summary>
+                      <div class="body">NOTICE: The Privacy Act of 1974 and applicable regulations require that you be furnished with the following information in connection with information collected for this permit purchase.
 
 AUTHORITY: 30 U.S.C. 601 et seq.; 43 U.S.C. 1181a; and 43 CFR 5400 (as applicable).
 
@@ -197,11 +206,15 @@ ROUTINE USES: The BWL may disclose information consistent with published routine
 
 EFFECT OF NOT PROVIDING INFORMATION: Providing the requested information is voluntary; however, failure to provide required information may prevent us from issuing your permit.
 </div>
-              </details>
-
-              <details id="termsDetail">
-                <summary>Terms and Conditions</summary>
-                <div class="body">Terms and Conditions (Demo Summary)
+                    </details>
+                  </div>
+                  <div class="agreement-item">
+                    <label class="checkline"><input type="checkbox" id="ackTerms" />
+                      I understand the rules for this permit (Terms and Conditions).
+                    </label>
+                    <details id="termsDetail">
+                      <summary>Terms and Conditions</summary>
+                      <div class="body">Terms and Conditions (Demo Summary)
 
 • All purchases are final; no refunds.
 • Permit is for personal use unless stated otherwise and may be non-transferable.
@@ -211,23 +224,8 @@ EFFECT OF NOT PROVIDING INFORMATION: Providing the requested information is volu
 
 Replace this demo text with the authoritative terms and conditions used by your production system.
 </div>
-              </details>
-
-              <div class="agreements" role="group" aria-label="Policy acknowledgements">
-                <div class="agreements-copy">
-                  <div class="eyebrow">Step 3</div>
-                  <div class="title">Review and accept</div>
-                  <p class="hint">Read the following summaries. You can open the full text before acknowledging.</p>
-                </div>
-                <div class="agreements-list">
-                  <label class="checkline"><input type="checkbox" id="ackPrivacy" />
-                    I understand how my information will be used (Privacy Act).
-                    <button class="inline-link" type="button" data-open-detail="#privacyDetail">View full text</button>
-                  </label>
-                  <label class="checkline"><input type="checkbox" id="ackTerms" />
-                    I understand the rules for this permit (Terms and Conditions).
-                    <button class="inline-link" type="button" data-open-detail="#termsDetail">View full text</button>
-                  </label>
+                    </details>
+                  </div>
                 </div>
               </div>
 

--- a/styles.css
+++ b/styles.css
@@ -131,10 +131,9 @@ body{
     .agreements .title{font-weight:900; font-size:17px; margin-top:4px;}
     .agreements .eyebrow{display:inline-block; padding:4px 8px; border-radius:999px; background:rgba(29,107,66,.12); color:var(--brand); font-size:12px; font-weight:800;}
     .agreements-list{display:grid; gap:10px;}
+    .agreement-item details{margin-top:6px;}
     .checkline{display:flex; gap:10px; font-weight:750; align-items:flex-start;}
     .checkline input{width:auto; margin-top:2px;}
-    .inline-link{border:0; background:none; color:var(--link); font-weight:750; cursor:pointer; padding:0; margin-left:6px; text-decoration:underline;}
-    .inline-link:hover{text-decoration:none;}
     /* Combobox */
     .combo{position:relative}
     .combo input{padding-right:38px}


### PR DESCRIPTION
## Summary
- remove the progress summary section and related JavaScript
- place acknowledgement checkboxes directly before their respective collapsible text and drop the extra view links
- clean up styles for the updated agreement layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6943906d93e88321afd2d1dc92cb4524)