### PR TITLE
Fix office dropdown selection handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -435,7 +435,9 @@
 
         div.appendChild(nameDiv);
         div.appendChild(idSpan);
-        div.addEventListener('mousedown', (e) => {
+        // Use click (not mousedown) so the selection works even if the input
+        // itself is disabled or blocked from taking focus.
+        div.addEventListener('click', (e) => {
           e.preventDefault();
           selectOffice(idx);
         });


### PR DESCRIPTION
## Summary
- change office list selection to use click events so offices can be chosen even when the text input cannot receive focus

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6943936e7cb083219459587d922ac764)