### PR TITLE
Replace banner SVG with URE flag image and add MOT/BWL logos to agency bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,18 +14,7 @@
     <div class="wrap">
       <div class="inner">
         <div class="flag" aria-hidden="true">
-          <svg viewBox="0 0 190 100" width="18" height="12" preserveAspectRatio="none">
-            <rect width="190" height="100" fill="#b22234"></rect>
-            <g fill="#fff">
-              <rect y="7.69" width="190" height="7.69"></rect>
-              <rect y="23.07" width="190" height="7.69"></rect>
-              <rect y="38.46" width="190" height="7.69"></rect>
-              <rect y="53.84" width="190" height="7.69"></rect>
-              <rect y="69.23" width="190" height="7.69"></rect>
-              <rect y="84.61" width="190" height="7.69"></rect>
-            </g>
-            <rect width="76" height="53.85" fill="#3c3b6e"></rect>
-          </svg>
+          <img src="logos/URE_flag.png" alt="" />
         </div>
         <div class="meta">An official site of the United Regions of Elsewhere</div>
         <button type="button" id="bannerToggle" aria-expanded="false" aria-controls="bannerDetails">Here’s how you know</button>
@@ -53,7 +42,10 @@
   <div class="agency-bar" role="banner">
     <div class="wrap">
       <div class="row">
-        <div class="seal" aria-hidden="true">MOT</div>
+        <div class="agency-logos" aria-hidden="true">
+          <img class="agency-logo mot" src="logos/MOT_logo.png" alt="" />
+          <img class="agency-logo bwl" src="logos/BWL_logo.png" alt="" />
+        </div>
         <div class="agency-title" aria-label="United Regions of Elsewhere Ministry of Outside Things, Bureau of Wandering Lands">
           <div class="top">MINISTRY OF OUTSIDE THINGS</div>
           <div class="bot">BUREAU OF WANDERING LANDS</div>

--- a/styles.css
+++ b/styles.css
@@ -39,6 +39,7 @@ body{
     .usa-banner{background:#f1f1f1; border-bottom:1px solid rgba(0,0,0,.12); font-size:13px;}
     .usa-banner .inner{display:flex; align-items:center; gap:10px; padding:9px 0;}
     .flag{width:18px; height:12px; border:1px solid rgba(0,0,0,.2); border-radius:2px; overflow:hidden}
+    .flag img{display:block; width:100%; height:100%; object-fit:cover}
     .usa-banner .meta{color:#222}
     .usa-banner button{margin-left:auto; font-size:13px; border:1px solid rgba(0,0,0,.18); background:#fff; padding:6px 10px; border-radius:10px; cursor:pointer;}
     .usa-banner button:focus{outline:3px solid var(--accent); outline-offset:2px}
@@ -51,7 +52,9 @@ body{
     /* Agency bar */
 .agency-bar{background:#0b0f19; color:#fff; padding:10px 0; box-shadow:0 12px 26px rgba(0,0,0,.18);}
     .agency-bar .row{display:flex; align-items:center; gap:12px;}
-    .seal{width:34px; height:34px; border-radius:10px; background:linear-gradient(135deg, rgba(255,255,255,.18), rgba(255,255,255,.05)); border:1px solid rgba(255,255,255,.18); display:grid; place-items:center; font-weight:900; letter-spacing:.02em;}
+    .agency-logos{display:flex; align-items:center; gap:8px;}
+    .agency-logo{display:block; height:34px; width:auto; object-fit:contain;}
+    .agency-logo.bwl{height:30px;}
     .agency-title{line-height:1.2}
     .agency-title .top{font-size:12px; opacity:.9}
     .agency-title .bot{font-size:14px; font-weight:800}


### PR DESCRIPTION
### Motivation
- Replace the inline URE banner SVG with the official `URE_flag.png` image for easier asset management and consistent branding.
- Surface the ministry and bureau logos in the agency bar instead of a text seal to improve visual identity for the agency header.
- Add minimal styling for the new image assets so they size and align correctly with the existing header layout.

### Description
- Updated `index.html` to replace the inline SVG flag with `<img src="logos/URE_flag.png">` and to replace the single `seal` element with two logos: `logos/MOT_logo.png` and `logos/BWL_logo.png` inside an `agency-logos` container.
- Updated `styles.css` to add `.flag img`, `.agency-logos`, `.agency-logo`, and `.agency-logo.bwl` rules to control sizing and layout of the new images.
- Changes are limited to the header/banner area and do not modify functional site behavior.

### Testing
- Started a local dev server with `python -m http.server 8000` and it served the site successfully.
- Ran a Playwright script that opened `http://127.0.0.1:8000/index.html` and captured a screenshot saved as `artifacts/ure-banner-logos.png`, which completed successfully.
- No automated unit tests were applicable to these static markup and style updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6946c25b1d788321b255a8e3b219c9d9)