### PR TITLE
Add delayed auto-focus and serialize step transition timers

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -100,8 +100,8 @@ body{
     .flow-step .step-toggle{background:transparent; border:0; padding:0; font-weight:900; font-size:16px; cursor:pointer; text-align:left; flex:1;}
     .flow-step .step-toggle:hover{text-decoration:underline;}
     .flow-step .step-status{font-size:13px; color:var(--muted);}
-    .flow-step .step-body{margin-top:10px;}
-    .flow-step.collapsed .step-body{display:none;}
+    .flow-step .step-body{margin-top:10px; max-height:3000px; opacity:1; overflow:hidden; visibility:visible; transition:max-height .45s ease, opacity .35s ease, margin-top .45s ease;}
+    .flow-step.collapsed .step-body{max-height:0; opacity:0; margin-top:0; pointer-events:none; visibility:hidden; transition:max-height .45s ease, opacity .3s ease, margin-top .45s ease, visibility 0s linear .45s;}
     .lock-note{margin-top:8px; font-size:13px; color:#2f4f4d; background:rgba(247,251,245,.85); border:1px dashed rgba(29,107,66,.35); padding:12px 13px; border-radius:12px;}
     /* Forms */
     label{font-weight:750; font-size:14px; color:#0d3b25}


### PR DESCRIPTION
### Motivation
- Make auto-advances smoother and less jarring by delaying focus until after the visual transition and preventing competing timers from interfering.
- Ensure programmatic step opens use the same timing controls as auto-advances while keeping manual toggles immediate.
- Keep Step 3 from being auto-collapsed so completion preserves the expanded state for user review.

### Description
- Introduced `STEP_FOCUS_DELAY_MS`, `stepFocusTimer`, and used a `stepTransitionToken` to serialize/cancel pending transitions in `setOpenStep` and prevent overlapping timers.
- Changed `setOpenStep` signature to `setOpenStep(idx, { source, scroll, focus })` with `focus` defaulting to `source === 'auto'`, and added delayed focusing of the first focusable element inside the step body using `focus({ preventScroll: true })`.
- Updated calls to `setOpenStep` to pass `{ source: 'auto' }` or `{ source: 'manual' }` as appropriate to control delays and focus behavior.
- Reworked collapse/expand visuals by setting `aria-hidden` on `.step-body` and adding CSS transitions for `max-height`, `opacity`, `margin-top`, and `visibility` to animate step body collapse/expand.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694bfffecb888321b8ef0280415aeb69)