### PR TITLE
Improve step transition animations and centralized focus handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -1032,6 +1032,7 @@
       if (!body) return;
       const focusables = body.querySelectorAll('input, select, textarea, button, a[href], [tabindex]');
       focusables.forEach(el => {
+        const isDisabled = el.disabled || el.getAttribute('aria-disabled') === 'true';
         if (enabled) {
           if (Object.prototype.hasOwnProperty.call(el.dataset, 'collapsedTab')) {
             const prev = el.dataset.collapsedTab;
@@ -1040,7 +1041,7 @@
           }
           el.removeAttribute('data-collapsed');
         } else {
-          if (!Object.prototype.hasOwnProperty.call(el.dataset, 'collapsedTab')) {
+          if (!Object.prototype.hasOwnProperty.call(el.dataset, 'collapsedTab') && !isDisabled) {
             el.dataset.collapsedTab = el.getAttribute('tabindex') || '';
           }
           el.setAttribute('tabindex', '-1');

--- a/styles.css
+++ b/styles.css
@@ -101,8 +101,8 @@ body{
     .flow-step .step-toggle:hover{text-decoration:underline;}
     .flow-step .step-status{font-size:13px; color:var(--muted);}
     .flow-step .step-body{margin-top:10px; overflow:hidden; max-height:0; opacity:0; transform:translateY(-6px); transition:max-height .36s ease, opacity .24s ease, transform .24s ease;}
-    .flow-step.collapsed .step-body{margin-top:0; pointer-events:none;}
-    .flow-step:not(.collapsed) .step-body{max-height:var(--step-body-max, 1200px); opacity:1; transform:translateY(0);}
+    .flow-step.collapsed .step-body{margin-top:0; pointer-events:none; overflow:hidden;}
+    .flow-step:not(.collapsed) .step-body{max-height:var(--step-body-max, 1200px); opacity:1; transform:translateY(0); overflow:visible;}
     .lock-note{margin-top:8px; font-size:13px; color:#2f4f4d; background:rgba(247,251,245,.85); border:1px dashed rgba(29,107,66,.35); padding:12px 13px; border-radius:12px;}
     /* Forms */
     label{font-weight:750; font-size:14px; color:#0d3b25}


### PR DESCRIPTION
### Motivation
- Make step changes feel smooth by animating collapse and expand concurrently and avoiding instant DOM jumps.
- Centralize transition timing and focus/scroll behavior so navigation between steps is consistent and accessible.
- Ensure Step 3 remains open after completion unless the user manually navigates back to earlier steps.
- Preserve existing validation and gating logic while only adjusting presentation and focus timing.

### Description
- Added a centralized transition helper `transitionToStep` and focus scheduler using `STEP_TRANSITION_MS` to coordinate timing and scrolling in `app.js`.
- Implemented `syncStepBodyHeight`, `setStepBodyFocusability`, and `applyCollapsedState` to compute `--step-body-max` and manage focusability of collapsed content in `app.js`.
- Reworked `updateStepUI` to use `aria-hidden` and call the new sync/apply functions, and stopped auto-collapsing Step 3 on completion to keep it expanded.
- Added CSS transitions for `.flow-step .step-body` (max-height/opacity/transform) in `styles.css` to animate expand/collapse smoothly.

### Testing
- Ran a visual smoke test by serving the app locally and capturing a screenshot with Playwright, which completed successfully and produced `artifacts/step-transition.png`.
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c4da71d548321b56f3e4daf9b396f)