### PR TITLE
Fix step transition animations and focus timing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -100,8 +100,9 @@ body{
     .flow-step .step-toggle{background:transparent; border:0; padding:0; font-weight:900; font-size:16px; cursor:pointer; text-align:left; flex:1;}
     .flow-step .step-toggle:hover{text-decoration:underline;}
     .flow-step .step-status{font-size:13px; color:var(--muted);}
-    .flow-step .step-body{margin-top:10px;}
-    .flow-step.collapsed .step-body{display:none;}
+    .flow-step .step-body{margin-top:10px; overflow:hidden; height:0; opacity:0; transform:translateY(-6px); transition:height .36s ease, opacity .24s ease, transform .24s ease;}
+    .flow-step.collapsed .step-body{margin-top:0; pointer-events:none;}
+    .flow-step:not(.collapsed) .step-body{opacity:1; transform:translateY(0);}
     .lock-note{margin-top:8px; font-size:13px; color:#2f4f4d; background:rgba(247,251,245,.85); border:1px dashed rgba(29,107,66,.35); padding:12px 13px; border-radius:12px;}
     /* Forms */
     label{font-weight:750; font-size:14px; color:#0d3b25}


### PR DESCRIPTION
### Motivation
- The previous expand/collapse approach led to clipped content and abrupt DOM jumps during step transitions. 
- Focus timing was unreliable during transitions causing unpredictable scrolling and focus jumps. 
- Collapsed content could remain focusable, which is bad for accessibility and keyboard users. 

### Description
- Replaced the `--step-body-max`/max-height approach with an explicit height animation implemented in `animateStepBody` that sets `height` and restores `auto` after transition. 
- Added `setStepBodyFocusability` and `applyCollapsedState` to toggle tabindex/`aria-hidden` for collapsed content so hidden elements are not focusable. 
- Updated `scheduleStepFocus` to listen for `transitionend` on the step body with a timeout fallback and introduced `transitionToStep` to centralize step-open, focus, and scroll behavior. 
- Adjusted CSS in `styles.css` to use `height` transitions and refined collapsed rules to prevent pointer events on hidden bodies. 

### Testing
- Started a local server with `python -m http.server` and captured a visual smoke test screenshot with Playwright saved to `artifacts/step-transition.png`, which completed successfully. 
- No automated unit tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c4da71d548321b56f3e4daf9b396f)