### PR TITLE
Add no-fee permit options and eligibility UI with demo no-fee issuance

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,6 +215,15 @@ Replace this demo text with the authoritative terms and conditions used by your 
 </div>
                     </details>
                   </div>
+                  <div class="agreement-item" id="eligibilityAgreement" style="display:none;">
+                    <label class="checkline"><input type="checkbox" id="ackEligibility" />
+                      <span id="eligibilityLabel">I certify that I meet the eligibility requirements for this permit.</span>
+                    </label>
+                    <details id="eligibilityDetail">
+                      <summary>Eligibility details</summary>
+                      <div class="body" id="eligibilityBody"></div>
+                    </details>
+                  </div>
                 </div>
               </div>
 
@@ -277,7 +286,7 @@ Replace this demo text with the authoritative terms and conditions used by your 
               <div class="icon" aria-hidden="true">i</div>
               <div class="txt">
                 <strong>What happens next</strong>
-                <ul>
+                <ul id="nextStepsList">
                   <li>You will be redirected to Pay.gov to complete payment.</li>
                   <li>After payment, you will return here to download and save your permit.</li>
                   <li>Keep your confirmation email for your records.</li>
@@ -288,6 +297,19 @@ Replace this demo text with the authoritative terms and conditions used by your 
               <button class="primary" type="button" id="confirmPaygov" disabled>Continue to Pay.gov</button>
             </div>
 
+            <div class="alert" id="confirmation" style="display:none; margin-top:12px;">
+              <div class="icon" aria-hidden="true">i</div>
+              <div class="txt">
+                <strong>Permit issued</strong>
+                <div class="small" style="margin-top:4px;">Reference: <span id="permitRef">—</span></div>
+                <div style="margin-top:10px;">
+                  <button class="primary" type="button" id="permitDownloadBtn">Download permit (PDF)</button>
+                </div>
+                <div class="hint" style="margin-top:8px;">
+                  Save the permit for your records. A copy is also sent to the email address you provided (demo behavior).
+                </div>
+              </div>
+            </div>
             <div class="summary" id="handoff" style="display:none; margin-top:14px;"></div>
           </section>
         </div>

--- a/products.json
+++ b/products.json
@@ -68,6 +68,63 @@
                   "url": "#"
                 }
               ]
+            },
+            {
+              "name": "Fuelwood Permit — Subsistence (ANILCA, No fee)",
+              "unit": "cord",
+              "price": 0,
+              "availableUntil": "2026-12-31",
+              "maxQty": 5,
+              "description": "No-fee permit for eligible subsistence users. Personal/family subsistence use only.",
+              "eligibility": {
+                "requiresCertification": true,
+                "basis": "ANILCA Title VIII subsistence eligibility (16 U.S.C. § 3113)",
+                "label": "I certify that I qualify for subsistence uses under ANILCA (16 U.S.C. § 3113) for this no-fee permit.",
+                "intro": "This no-fee permit option is available only to eligible subsistence users in Alaska.",
+                "bullets": [
+                  "I am eligible for subsistence uses as defined in 16 U.S.C. § 3113.",
+                  "I will use the forest products collected under this permit for personal or family subsistence use (not commercial resale).",
+                  "I understand that false statements may be subject to penalties."
+                ],
+                "citations": [
+                  {
+                    "label": "16 U.S.C. § 3113 (U.S. House Office of Law Revision Counsel)",
+                    "url": "https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title16-section3113"
+                  },
+                  {
+                    "label": "16 U.S.C. § 3113 (Cornell LII)",
+                    "url": "https://www.law.cornell.edu/uscode/text/16/3113"
+                  }
+                ]
+              },
+              "requiredDocs": [
+                {
+                  "label": "Map",
+                  "url": "#"
+                },
+                {
+                  "label": "Stipulations",
+                  "url": "#"
+                }
+              ]
+            },
+            {
+              "name": "Fuelwood Permit — Free Use (No fee)",
+              "unit": "cord",
+              "price": 0,
+              "availableUntil": "2026-12-31",
+              "maxQty": 2,
+              "description": "No-fee personal use permit issued under free-use authority. Not for commercial resale.",
+              "requiredDocs": [
+                {
+                  "label": "Map",
+                  "url": "#"
+                },
+                {
+                  "label": "Stipulations",
+                  "url": "#"
+                }
+              ]
             }
           ],
           "christmas": [
@@ -100,6 +157,24 @@
               "availableUntil": "2025-12-25",
               "maxQty": 3,
               "description": "Limited areas; verify winter travel conditions before departure.",
+              "requiredDocs": [
+                {
+                  "label": "Map",
+                  "url": "#"
+                },
+                {
+                  "label": "Stipulations",
+                  "url": "#"
+                }
+              ]
+            },
+            {
+              "name": "Christmas Tree Permit — Free Use (No fee)",
+              "unit": "tree",
+              "price": 0,
+              "availableUntil": "2025-12-25",
+              "maxQty": 1,
+              "description": "No-fee personal use tree permit for designated areas.",
               "requiredDocs": [
                 {
                   "label": "Map",
@@ -194,6 +269,63 @@
                   "url": "#"
                 }
               ]
+            },
+            {
+              "name": "Fuelwood Permit — Subsistence (ANILCA, No fee)",
+              "unit": "cord",
+              "price": 0,
+              "availableUntil": "2026-12-31",
+              "maxQty": 4,
+              "description": "No-fee permit for eligible subsistence users. Personal/family subsistence use only.",
+              "eligibility": {
+                "requiresCertification": true,
+                "basis": "ANILCA Title VIII subsistence eligibility (16 U.S.C. § 3113)",
+                "label": "I certify that I qualify for subsistence uses under ANILCA (16 U.S.C. § 3113) for this no-fee permit.",
+                "intro": "This no-fee permit option is available only to eligible subsistence users in Alaska.",
+                "bullets": [
+                  "I am eligible for subsistence uses as defined in 16 U.S.C. § 3113.",
+                  "I will use the forest products collected under this permit for personal or family subsistence use (not commercial resale).",
+                  "I understand that false statements may be subject to penalties."
+                ],
+                "citations": [
+                  {
+                    "label": "16 U.S.C. § 3113 (U.S. House Office of Law Revision Counsel)",
+                    "url": "https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title16-section3113"
+                  },
+                  {
+                    "label": "16 U.S.C. § 3113 (Cornell LII)",
+                    "url": "https://www.law.cornell.edu/uscode/text/16/3113"
+                  }
+                ]
+              },
+              "requiredDocs": [
+                {
+                  "label": "Map",
+                  "url": "#"
+                },
+                {
+                  "label": "Stipulations",
+                  "url": "#"
+                }
+              ]
+            },
+            {
+              "name": "Fuelwood Permit — Free Use (No fee)",
+              "unit": "cord",
+              "price": 0,
+              "availableUntil": "2026-12-31",
+              "maxQty": 2,
+              "description": "No-fee personal use permit issued under free-use authority. Not for commercial resale.",
+              "requiredDocs": [
+                {
+                  "label": "Map",
+                  "url": "#"
+                },
+                {
+                  "label": "Stipulations",
+                  "url": "#"
+                }
+              ]
             }
           ],
           "christmas": [
@@ -222,6 +354,24 @@
               "availableUntil": "2025-12-25",
               "maxQty": 5,
               "description": "Designated areas only.",
+              "requiredDocs": [
+                {
+                  "label": "Map",
+                  "url": "#"
+                },
+                {
+                  "label": "Stipulations",
+                  "url": "#"
+                }
+              ]
+            },
+            {
+              "name": "Christmas Tree Permit — Free Use (No fee)",
+              "unit": "tree",
+              "price": 0,
+              "availableUntil": "2025-12-25",
+              "maxQty": 1,
+              "description": "No-fee personal use tree permit for designated areas.",
               "requiredDocs": [
                 {
                   "label": "Map",
@@ -315,6 +465,24 @@
                   "url": "#"
                 }
               ]
+            },
+            {
+              "name": "Fuelwood Permit — Free Use (No fee)",
+              "unit": "cord",
+              "price": 0,
+              "availableUntil": "2026-12-31",
+              "maxQty": 1,
+              "description": "No-fee personal use permit issued under free-use authority. Not for commercial resale.",
+              "requiredDocs": [
+                {
+                  "label": "Map",
+                  "url": "#"
+                },
+                {
+                  "label": "Stipulations",
+                  "url": "#"
+                }
+              ]
             }
           ],
           "christmas": [
@@ -347,6 +515,24 @@
               "availableUntil": "2025-12-24",
               "maxQty": 3,
               "description": "Limited permit; verify availability.",
+              "requiredDocs": [
+                {
+                  "label": "Map",
+                  "url": "#"
+                },
+                {
+                  "label": "Stipulations",
+                  "url": "#"
+                }
+              ]
+            },
+            {
+              "name": "Christmas Tree Permit — Free Use (No fee)",
+              "unit": "tree",
+              "price": 0,
+              "availableUntil": "2025-12-24",
+              "maxQty": 1,
+              "description": "No-fee personal use tree permit for designated areas.",
               "requiredDocs": [
                 {
                   "label": "Map",
@@ -431,6 +617,24 @@
                   "url": "#"
                 }
               ]
+            },
+            {
+              "name": "Fuelwood Permit — Free Use (No fee)",
+              "unit": "cord",
+              "price": 0,
+              "availableUntil": "2026-12-31",
+              "maxQty": 2,
+              "description": "No-fee personal use permit issued under free-use authority. Not for commercial resale.",
+              "requiredDocs": [
+                {
+                  "label": "Map",
+                  "url": "#"
+                },
+                {
+                  "label": "Stipulations",
+                  "url": "#"
+                }
+              ]
             }
           ],
           "christmas": [
@@ -455,6 +659,24 @@
               "availableUntil": "2025-12-24",
               "maxQty": 5,
               "description": "Designated cutting areas only.",
+              "requiredDocs": [
+                {
+                  "label": "Map",
+                  "url": "#"
+                },
+                {
+                  "label": "Stipulations",
+                  "url": "#"
+                }
+              ]
+            },
+            {
+              "name": "Christmas Tree Permit — Free Use (No fee)",
+              "unit": "tree",
+              "price": 0,
+              "availableUntil": "2025-12-24",
+              "maxQty": 1,
+              "description": "No-fee personal use tree permit for designated areas.",
               "requiredDocs": [
                 {
                   "label": "Map",


### PR DESCRIPTION
### Motivation
- Add no-fee permit options (subsistence and free-use) to the product catalog so zero-price permits are available across offices.
- Require and display an eligibility attestation for permits that legally require certification (e.g., ANILCA subsistence permits).
- Provide an end-to-end demo path for no-fee issuance so users can confirm and immediately download a permit PDF in the UI.

### Description
- Update `products.json` to add multiple no-fee permit entries including `Fuelwood Permit — Subsistence (ANILCA, No fee)` with an `eligibility` object and several `Free Use (No fee)` permits across offices.
- Add eligibility UI and confirmation markup in `index.html` including `id="eligibilityAgreement"`, `id="ackEligibility"`, `id="eligibilityLabel"`, `id="eligibilityBody"`, `id="nextStepsList"`, `id="confirmation"`, `id="permitRef"`, and `id="permitDownloadBtn"`.
- Wire the new elements and behaviors in `app.js`: persist/restore `ackEligibility`, implement `productRequiresEligibility()`, `ackRequirementsMet()`, `renderEligibilityAgreement()`, `configureCheckoutCopy()`, `buildDemoPermitPdf()`, `clearConfirmation()`, `feeLabelForUnit()`, and `totalLabelFor()`, update `getFieldContainer()` lookup, and require eligibility acknowledgement when applicable.
- Implement demo no-fee issuance flow that generates a simple PDF blob, exposes a download URL, shows a confirmation UI with a permit reference, and revokes object URLs on state changes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6951ae2eaec48321bcf8f761c2cd3d2b)