### PR TITLE
Fix office dropdown overflow and enable quantity input on product selection

### DIFF
--- a/app.js
+++ b/app.js
@@ -246,6 +246,7 @@
         qtyHint.textContent = `Enter 1–${p.maxQty} ${p.unit}(s). Price: ${feeLabelForUnit(p.price, p.unit)}.`;
         qtyEl.min = 1;
         qtyEl.max = p.maxQty || '';
+        setControlEnabled(qtyEl, true);
         qtySection.style.display = 'block';
         if (savedModel.qty) {
           qtyEl.value = savedModel.qty;
@@ -338,6 +339,7 @@
       totalCalc.textContent = '';
       qtyGuard.textContent = '';
       model.qty = 0;
+      setControlEnabled(qtyEl, false);
       qtySection.style.display = 'none';
       productListEl.innerHTML = '';
     }
@@ -844,6 +846,7 @@
       model.productIndex = null;
       model.product = null;
       qtySection.style.display = 'none';
+      setControlEnabled(qtyEl, false);
       stepState.completed[1] = false;
       stepState.available[2] = false;
 
@@ -957,6 +960,7 @@
         qtyEl.value = '';
         totalEl.value = '';
         totalCalc.textContent = '';
+        setControlEnabled(qtyEl, true);
         qtySection.style.display = 'block';
         model.qty = 0;
         stepState.completed[1] = false;

--- a/styles.css
+++ b/styles.css
@@ -104,7 +104,8 @@ body{
     .flow-step .step-toggle:hover{text-decoration:underline;}
     .flow-step .step-status{font-size:13px; color:var(--muted);}
     .flow-step .step-body{margin-top:10px; display:grid; grid-template-rows:1fr; opacity:1; transition:grid-template-rows .2s ease, opacity .2s ease;}
-    .flow-step .step-body-inner{overflow:hidden;}
+    .flow-step .step-body-inner{overflow:visible;}
+    .flow-step.collapsed .step-body-inner{overflow:hidden;}
     .flow-step.collapsed .step-body{grid-template-rows:0fr; opacity:0; margin-top:0; pointer-events:none;}
     .lock-note{display:none; margin-top:8px; font-size:13px; color:#2f4f4d; background:rgba(247,251,245,.85); border:1px dashed rgba(29,107,66,.35); padding:12px 13px; border-radius:12px;}
     /* Forms */


### PR DESCRIPTION
### Motivation
- The office combobox dropdown was being clipped by the step container, preventing users from seeing the full list of offices.
- The quantity field remained inactive after selecting a product or restoring state because its enabled/disabled state was not explicitly managed.

### Description
- Allow the office dropdown to overflow the step container by changing `.flow-step .step-body-inner` to `overflow: visible` and adding a collapsed rule to restore clipping in `styles.css`.
- Explicitly toggle the quantity input enabled state using `setControlEnabled(qtyEl, ...)` when resetting products, restoring saved product selection, rendering product lists, and when a product card is selected in `app.js`.
- Ensure `qtyEl` is disabled when no product is selected and enabled when a valid product with limits is chosen by the user.

### Testing
- Started a local static server with `python -m http.server 8000` to host the app, which served files successfully.
- Attempted an automated end-to-end interaction via a Playwright script to select a product and populate `#qty`, but the script failed due to Playwright/Chromium timeouts and a browser crash, so the full interaction could not be validated end-to-end.
- Performed static checks and manual code inspection to verify the new `setControlEnabled` calls and CSS changes were applied and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6951d0f3b02883218393cf55052450e4)