### PR TITLE
Auto-open next step on completion and preserve expanded sections

### DIFF
--- a/app.js
+++ b/app.js
@@ -1545,6 +1545,7 @@
     }
 
     function commitQuantity({ showErrors = true } = {}) {
+      const wasCompleted = stepState.completed[1];
       const msg = getFieldErrorMessage(qtyEl);
       if (showErrors) {
         setFieldError(qtyEl, msg);
@@ -1561,6 +1562,9 @@
       const ok = validateQty();
       stepState.completed[1] = ok;
       stepState.available[2] = ok;
+      if (ok && !wasCompleted) {
+        stepState.open[2] = true;
+      }
       updateStepUI(model.step);
       updateReviewActions();
       persistState();
@@ -1600,7 +1604,7 @@
     function openStepIfAvailable(idx, { scrollIfNeeded = false } = {}) {
       if (!stepState.available[idx]) return;
       if (stepState.open[idx]) return false;
-      setStepOpenState(idx, true, { collapseOthers: true, scrollIfNeeded });
+      setStepOpenState(idx, true, { collapseOthers: false, scrollIfNeeded });
       return true;
     }
 
@@ -1617,6 +1621,7 @@
     }
 
     function attemptAdvanceFromStep1() {
+      const wasCompleted = stepState.completed[0];
       validateProductType({ showErrors: false });
       const ok = validateStep1();
       stepState.available[1] = ok;
@@ -1631,6 +1636,9 @@
         return;
       }
 
+      if (ok && !wasCompleted) {
+        stepState.open[1] = true;
+      }
       renderProducts();
 
       updateStepUI(model.step);
@@ -1841,7 +1849,7 @@
     stepToggles.forEach((btn, idx) => {
       btn.addEventListener('click', () => {
         if (!stepState.available[idx]) return;
-        setStepOpenState(idx, true, { collapseOthers: true, scrollIfNeeded: true });
+        setStepOpenState(idx, true, { collapseOthers: false, scrollIfNeeded: true });
       });
     });
 
@@ -1849,11 +1857,12 @@
       btn.addEventListener('click', () => {
         const idx = Number(btn.dataset.editStep);
         if (!stepState.available[idx]) return;
-        setStepOpenState(idx, true, { collapseOthers: true, scrollIfNeeded: true });
+        setStepOpenState(idx, true, { collapseOthers: false, scrollIfNeeded: true });
       });
     });
 
     qtyEl.addEventListener('input', () => {
+      const wasCompleted = stepState.completed[1];
       setFieldError(qtyEl, '');
       const max = Number(qtyEl.max || '');
       const val = Number(qtyEl.value);
@@ -1865,6 +1874,9 @@
       if (!ok && totalAmount) totalAmount.textContent = '—';
       stepState.completed[1] = ok;
       stepState.available[2] = ok;
+      if (ok && !wasCompleted) {
+        stepState.open[2] = true;
+      }
       stepState.completed[2] = false;
       clearConfirmation();
       hideReview();


### PR DESCRIPTION
### Motivation
- Auto-expand the next section when a prior section is completed while keeping previously expanded sections open, and avoid collapsing sections when users interact with step headers or edit controls.
- Make explicit user actions (Enter/Tab) behave as intended while still unlocking subsequent steps when the prior step becomes valid.

### Description
- In `app.js` added `wasCompleted` guards and set `stepState.open[1] = true` in `attemptAdvanceFromStep1` so Step 2 auto-opens when Step 1 transitions from incomplete to complete.
- Updated quantity handling in the `qtyEl` input handler and `commitQuantity` to set `stepState.open[2] = true` when a valid quantity is entered, thereby auto-opening Step 3 on first successful completion.
- Changed calls to `setStepOpenState` (used by step toggles and progress edit buttons) and `openStepIfAvailable` to pass `collapseOthers: false` so opening a step does not collapse previously opened sections.
- Added small state checks to avoid re-opening steps unnecessarily on repeated interactions.

### Testing
- Started a local dev server with `python -m http.server` to serve the app, which launched successfully.
- Attempted an automated end-to-end script with Playwright to exercise the flow and capture a screenshot, but the Playwright run failed due to a browser crash / timeout (SIGSEGV). 
- No unit tests were added and no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956b64ec9288321a5cd0a829f96f860)