### PR TITLE
Remove step progress indicator and bureau notice

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,13 +73,6 @@
     const errorBox = document.getElementById('errorBox');
     const errorList = document.getElementById('errorList');
 
-    const progressTitle = document.getElementById('progressTitle');
-    const progressSub = document.getElementById('progressSub');
-    const progressBar = document.getElementById('progressBar');
-    const progressCount = document.getElementById('progressCount');
-    const progressCurrent = document.getElementById('progressCurrent');
-    const progressSteps = Array.from(document.querySelectorAll('[data-progress-step]'));
-    const progressEditButtons = Array.from(document.querySelectorAll('[data-edit-step]'));
     const stepSections = [
       document.getElementById('step1'),
       document.getElementById('step2'),
@@ -1114,16 +1107,9 @@
       });
       updateLockNotes();
       applyLockState();
-      updateProgressHeader(activeStepIndex);
       stepState.available.forEach((available, i) => {
         if (available && !prevAvailability[i]) {
           announce(`Step ${i + 1} unlocked. You can now complete this section.`);
-      
-          const item = progressSteps[i];
-          if (item) {
-            item.classList.add('just-unlocked');
-            window.setTimeout(() => item.classList.remove('just-unlocked'), 1200);
-          }
         }
       });
       prevAvailability = [...stepState.available];
@@ -1132,42 +1118,6 @@
         announce(`Now viewing Step ${activeStepIndex + 1}. ${stepSections[activeStepIndex]?.getAttribute('aria-label') || ''}`.trim());
         lastAnnouncedStep = activeStepIndex;
       }
-    }
-
-    function updateProgressHeader(activeStepIndex = stepState.open.findIndex(Boolean)) {
-      const totalSteps = stepSections.length;
-      const activeIdx = activeStepIndex === -1 ? model.step : activeStepIndex;
-      const stepNames = [
-        'What + Where',
-        'Permit',
-        'Agree + Info'
-      ];
-      const totalStepCount = stepNames.length;
-      const activeName = stepNames[activeIdx] || stepNames[0];
-      if (progressTitle) progressTitle.textContent = `Step ${activeIdx + 1} of ${totalStepCount}: ${activeName}`;
-      if (progressCount) progressCount.textContent = `Step ${activeIdx + 1} of ${totalStepCount}`;
-      if (progressCurrent) progressCurrent.textContent = activeName;
-
-      const status = !stepState.available[activeIdx]
-        ? 'Locked'
-        : stepState.completed[activeIdx]
-          ? 'Completed'
-          : 'In progress';
-      if (progressSub) progressSub.textContent = status;
-
-      const progressPercent = totalSteps > 1 ? (activeIdx / (totalSteps - 1)) * 100 : 0;
-      if (progressBar) progressBar.style.width = `${progressPercent}%`;
-
-      progressSteps.forEach((step, idx) => {
-        step.classList.toggle('is-active', idx === activeIdx);
-        step.classList.toggle('is-complete', stepState.completed[idx]);
-        if (idx === activeIdx) {
-          step.setAttribute('aria-current', 'step');
-        } else {
-          step.removeAttribute('aria-current');
-        }
-      });
-
     }
 
     function updateReviewActions() {
@@ -1851,14 +1801,6 @@
 
     stepToggles.forEach((btn, idx) => {
       btn.addEventListener('click', () => {
-        if (!stepState.available[idx]) return;
-        setStepOpenState(idx, true, { collapseOthers: false, scrollIfNeeded: true });
-      });
-    });
-
-    progressEditButtons.forEach((btn) => {
-      btn.addEventListener('click', () => {
-        const idx = Number(btn.dataset.editStep);
         if (!stepState.available[idx]) return;
         setStepOpenState(idx, true, { collapseOthers: false, scrollIfNeeded: true });
       });

--- a/index.html
+++ b/index.html
@@ -65,8 +65,6 @@
         <section class="pagehead" aria-label="Page title and instructions">
           <h1>Online Forest Product Permits</h1>
           <p class="hero-subtitle">Choose what and where you’re collecting, select a permit, and complete checkout. We’ll email your permit package to you.</p>
-          <p class="federal-note">Permits obtained through this site are issued by the Bureau of Wandering Lands.</p>
-
           <div class="alert" role="status" aria-live="polite">
             <div class="icon" aria-hidden="true">i</div>
             <div class="txt">
@@ -76,36 +74,6 @@
           </div>
         </section>
       </div>
-
-      <section class="progress-header" aria-label="Progress" id="progressHeader">
-        <div class="progress-status sr-only" aria-live="polite">
-          <div class="progress-title" id="progressTitle">Step 1 of 3: What + Where</div>
-          <div class="progress-sub" id="progressSub">In progress</div>
-        </div>
-        <div class="progress-meta" aria-hidden="true">
-          <div class="progress-count" id="progressCount">Step 1 of 3</div>
-          <div class="progress-current" id="progressCurrent">What + Where</div>
-        </div>
-        <div class="progress-stepper" role="navigation" aria-label="Permit steps">
-          <div class="progress-track">
-            <div class="progress-line" aria-hidden="true">
-              <span class="progress-line-bg"></span>
-              <span class="progress-line-fill" id="progressBar"></span>
-            </div>
-            <ol class="progress-steps" id="progressSteps">
-              <li class="progress-step" data-progress-step="0" aria-label="Step 1 of 3: What + Where">
-                <span class="progress-dot" aria-hidden="true"></span>
-              </li>
-              <li class="progress-step" data-progress-step="1" aria-label="Step 2 of 3: Permit">
-                <span class="progress-dot" aria-hidden="true"></span>
-              </li>
-              <li class="progress-step" data-progress-step="2" aria-label="Step 3 of 3: Agree + Info">
-                <span class="progress-dot" aria-hidden="true"></span>
-              </li>
-            </ol>
-          </div>
-        </div>
-      </section>
 
       <section class="layout" style="margin-top: 8px;">
         <div class="card" role="region" aria-label="Form content">

--- a/styles.css
+++ b/styles.css
@@ -122,7 +122,6 @@ body{
     .pagehead h1{margin:0; font-size:var(--font-size-h1); letter-spacing:-.02em}
 .pagehead p{margin:6px 0 0; color:var(--muted); max-width:80ch}
 .hero-subtitle{font-size:16px; color:var(--muted); margin-top:6px;}
-.federal-note{font-weight:700; margin-top:12px; color:#0d3b25; background:rgba(29,107,66,.10); padding:12px 14px; border-radius:var(--radius-input); display:inline-block; box-shadow:var(--shadow-sm); border:1px solid rgba(29,107,66,.18);}
     .prototype-banner{background:#b42318; color:#fff; text-align:center; padding:10px 14px; font-weight:800; letter-spacing:.02em;}
     /* Alerts */
 .alert{display:flex; gap:10px; align-items:flex-start; border:1px solid rgba(29,107,66,.2); background:rgba(29,107,66,.08); border-radius:var(--radius-card); padding:12px 14px; margin-top:14px; box-shadow:var(--shadow-sm);}
@@ -134,89 +133,6 @@ body{
     .layout{display:grid; gap:18px; align-items:start}
     @media(min-width: 980px){ .layout{grid-template-columns: minmax(0, 1.25fr) 340px; gap:26px; align-items:start} }
 .card{background:var(--card); border:1px solid var(--border); border-radius:var(--radius-card); box-shadow:var(--shadow-md); padding:16px; position:relative; overflow:visible;}
-    /* Progress header */
-    .progress-header{
-      position:sticky;
-      top:0;
-      z-index:30;
-      margin:4px 0 8px;
-      background:rgba(255,255,255,.98);
-      border-bottom:1px solid var(--color-border);
-      box-shadow:none;
-      padding:4px 0 6px;
-      display:grid;
-      gap:2px;
-      min-height:28px;
-    }
-    .progress-meta{
-      display:flex;
-      justify-content:space-between;
-      align-items:center;
-      gap:12px;
-      font-size:12px;
-      color:var(--muted);
-    }
-    .progress-count{font-weight:600; letter-spacing:.01em;}
-    .progress-current{font-weight:700; color:var(--ink); font-size:13px;}
-    .progress-stepper{position:relative; --dot-size:4px; --dot-active-size:7px;}
-    .progress-track{position:relative; min-height:12px;}
-    .progress-steps{
-      list-style:none;
-      display:flex;
-      justify-content:space-between;
-      align-items:center;
-      gap:0;
-      margin:0;
-      padding:0;
-      position:relative;
-      z-index:2;
-    }
-    .progress-step{display:flex; align-items:center; justify-content:center;}
-    .progress-dot{
-      width:var(--dot-size);
-      height:var(--dot-size);
-      border-radius:999px;
-      background:rgba(15,28,31,.28);
-      transition:width var(--motion-fast) var(--motion-ease), height var(--motion-fast) var(--motion-ease), background var(--motion-fast) var(--motion-ease);
-    }
-    .progress-step.is-active .progress-dot{
-      width:var(--dot-active-size);
-      height:var(--dot-active-size);
-      background:var(--color-primary);
-    }
-    .progress-step.is-complete .progress-dot{
-      background:var(--color-primary);
-    }
-    .progress-step{opacity:.55;}
-    .progress-step.is-active,
-    .progress-step.is-complete{opacity:1;}
-    .progress-line{
-      position:absolute;
-      left:0;
-      right:0;
-      top:50%;
-      transform:translateY(-50%);
-      height:2px;
-    }
-    .progress-line-bg,
-    .progress-line-fill{
-      position:absolute;
-      left:0;
-      top:0;
-      height:100%;
-      border-radius:999px;
-    }
-    .progress-line-bg{width:100%; background:rgba(15,28,31,.2);}
-    .progress-line-fill{
-      width:0%;
-      background:var(--color-primary);
-      transition:width var(--motion-base) var(--motion-ease);
-    }
-    @media (max-width: 640px){
-      .progress-header{padding:6px 0 6px;}
-      .progress-meta{font-size:12px;}
-      .progress-current{font-size:12px;}
-    }
     /* Stepper */
     .stepper{display:flex; flex-wrap:wrap; gap:10px; padding:12px; border-radius:var(--radius-card); border:1px solid var(--color-border); background:rgba(255,255,255,.7); box-shadow:var(--shadow-sm);}
     .step{display:flex; align-items:center; gap:10px; padding:12px 14px; border-radius:var(--radius-input); border:1px solid var(--color-border); background:var(--color-surface); min-width: 210px; cursor:pointer; text-align:left; transition: border-color var(--motion-fast) var(--motion-ease), box-shadow var(--motion-fast) var(--motion-ease), transform var(--motion-fast) var(--motion-ease); box-shadow:var(--shadow-sm);}


### PR DESCRIPTION
### Motivation

- Remove the unused step progress indicator UI and any associated variables, styles, and script hooks to simplify the form flow.
- Remove the static notice sentence about the "Bureau of Wandering Lands" from the hero content.
- Clean up styling that was only used by the removed progress header and federal note.

### Description

- Deleted the progress header markup from `index.html` and removed the single-sentence federal note from the hero section.
- Removed progress-related DOM references, the `updateProgressHeader` function, and `progressEditButtons` handlers from `app.js` and updated the surrounding step logic to no longer call the removed helpers.
- Removed the `.progress-*` CSS block and the now-unused `.federal-note` rule from `styles.css`.
- Kept step toggles and step gating behavior intact while removing only the step progress indicator surface and hooks.

### Testing

- Ran a local HTTP server with `python -m http.server` and captured a page screenshot using Playwright, which completed successfully and produced an artifact.
- Quick repository search (`rg`) and code inspection were used to verify progress-related identifiers and styles were removed, with no script errors observed in the high-level smoke check.
- No unit test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956cf1474c88321a4905f229ed64dbe)