### PR TITLE
Remove MOT logo and enlarge BWL logo in agency bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,6 @@
     <div class="wrap">
       <div class="row">
         <div class="agency-logos" aria-hidden="true">
-          <img class="agency-logo mot" src="logos/MOT_logo.png" alt="" />
           <img class="agency-logo bwl" src="logos/BWL_logo.png" alt="" />
         </div>
         <div class="agency-title" aria-label="United Regions of Elsewhere Ministry of Outside Things, Bureau of Wandering Lands">

--- a/styles.css
+++ b/styles.css
@@ -106,9 +106,8 @@ body{
     /* Agency bar */
 .agency-bar{background:#0b0f19; color:#fff; padding:10px 0; box-shadow:0 10px 20px rgba(0,0,0,.18);}
     .agency-bar .row{display:flex; align-items:center; gap:12px;}
-    .agency-logos{display:flex; align-items:center; gap:8px;}
-    .agency-logo{display:block; height:34px; width:auto; object-fit:contain;}
-    .agency-logo.bwl{height:30px;}
+    .agency-logos{display:flex; align-items:center;}
+    .agency-logo{display:block; height:44px; width:auto; object-fit:contain;}
     .agency-title{line-height:1.2}
     .agency-title .top{font-size:12px; opacity:.9}
     .agency-title .bot{font-size:14px; font-weight:800}


### PR DESCRIPTION
### Motivation
- Free the visual space occupied by the MOT mark so the BWL identity can occupy the header more prominently.
- Ensure the remaining logo scales and aligns well with the existing agency title and action links.

### Description
- Remove the MOT image element from `index.html` by deleting the `<img class="agency-logo mot" ...>` node.
- Increase the displayed logo size by updating `.agency-logo` height to `44px` and remove the previous `.agency-logo.bwl` override in `styles.css`.
- Tighten the logo container by removing the gap from `.agency-logos` to improve spacing with the title and action links.

### Testing
- Started a local server with `python -m http.server` and served `index.html`, which completed successfully.
- Captured a visual verification screenshot using a Playwright script at viewport `1319x440`, which produced `artifacts/agency-bar.png` successfully.
- No automated unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956d19377408321abe41a9dd20a731c)