### PR TITLE
Update permit page headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Online Forest Product Permits — Prototype</title>
+  <title>Forest Product Permits | Bureau of Wandering Lands</title>
   <link rel="stylesheet" href="styles.css" />
   <link rel="icon" href="images/favicon.ico" />
 </head>
@@ -62,7 +62,8 @@
     <div class="wrap">
       <div class="hero-band">
         <section class="pagehead" aria-label="Page title and instructions">
-          <h1>Online Forest Product Permits</h1>
+          <h1>Get a Forest Product Permit</h1>
+          <p class="issuer-line">Issued by the Bureau of Wandering Lands (BWL)</p>
           <p class="hero-subtitle">Choose what and where you’re collecting, select a permit, and complete checkout. We’ll email your permit package to you.</p>
           <div class="alert" role="status" aria-live="polite">
             <div class="icon" aria-hidden="true">i</div>

--- a/styles.css
+++ b/styles.css
@@ -121,6 +121,7 @@ body{
     .pagehead h1{margin:0; font-size:var(--font-size-h1); letter-spacing:-.02em}
 .pagehead p{margin:6px 0 0; color:var(--muted); max-width:80ch}
 .hero-subtitle{font-size:16px; color:var(--muted); margin-top:6px;}
+.issuer-line{font-size:14px; color:var(--muted); margin-top:6px;}
     .prototype-banner{background:#b42318; color:#fff; text-align:center; padding:10px 14px; font-weight:800; letter-spacing:.02em;}
     /* Alerts */
 .alert{display:flex; gap:10px; align-items:flex-start; border:1px solid rgba(29,107,66,.2); background:rgba(29,107,66,.08); border-radius:var(--radius-card); padding:12px 14px; margin-top:14px; box-shadow:var(--shadow-sm);}


### PR DESCRIPTION
### Motivation
- Improve the page title for clearer browser/SEO messaging by referencing the Bureau of Wandering Lands.
- Make the primary page heading more action-oriented for users seeking permits.
- Surface the issuing agency directly below the H1 so users immediately see the permit issuer.

### Description
- Updated the document `<title>` to `Forest Product Permits | Bureau of Wandering Lands` in `index.html`.
- Replaced the H1 with `Get a Forest Product Permit` and added an issuer line `<p class="issuer-line">Issued by the Bureau of Wandering Lands (BWL)</p>` in `index.html`.
- Added a `.issuer-line` style rule to `styles.css` to match the page head styling.

### Testing
- Launched a local server with `python -m http.server` and captured a full-page screenshot using a Playwright script, which completed successfully.
- No unit or integration test suites were run for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695707e06cf08321a9f1f76f7bc9c5c3)