### PR TITLE
Adjust product type cards for mobile two-column grid

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -178,6 +178,13 @@ body{
     .ptype-card input:focus-visible + .ptype-card-body{outline:3px solid var(--color-focus); outline-offset:2px;}
     .ptype-card input:checked + .ptype-card-body{background:rgba(29,107,66,.08); border:1px solid rgba(29,107,66,.4); box-shadow:var(--shadow-md);}
     .ptype-card input:disabled + .ptype-card-body{opacity:.6; cursor:not-allowed;}
+    @media(max-width: 640px){
+      .ptype-grid{grid-template-columns: repeat(2, minmax(0, 1fr)); gap:10px;}
+      .ptype-card{padding:4px;}
+      .ptype-card-body{flex-direction:column; gap:6px; padding:10px 8px; text-align:center;}
+      .ptype-card img{width:44px; height:44px; border-radius:10px; padding:6px;}
+      .ptype-card-name{font-size:13px;}
+    }
     input, select, textarea{width:100%; padding:12px 13px; border:1px solid rgba(29,107,66,.28); border-radius:var(--radius-input); font-size:15px; background:var(--field); box-shadow:inset 0 1px 0 rgba(255,255,255,.6);}
     input:focus-visible, select:focus-visible, textarea:focus-visible, button:focus-visible, summary:focus-visible{outline:3px solid var(--color-focus); outline-offset:2px; box-shadow:0 0 0 3px rgba(37,111,176,.25);}
     .row{display:grid; gap:8px}


### PR DESCRIPTION
### Motivation
- Product type cards consumed excessive vertical space on mobile and needed a more compact layout.  
- Present product types as smaller icon+label tiles in a 2-column grid to reduce scrolling on phones.  

### Description
- Updated `styles.css` to add an `@media(max-width: 640px)` rule that makes `.ptype-grid` a two-column grid (`repeat(2, minmax(0, 1fr))`).  
- Tightened spacing and sizing by reducing `.ptype-card` padding, switching `.ptype-card-body` to column layout, shrinking `.ptype-card img` to 44x44, and reducing `.ptype-card-name` font size.  
- Change is purely CSS; no HTML or JS changes were made.  

### Testing
- Launched a local preview with `python -m http.server 8000` to serve the site, which started successfully.  
- Attempted an automated Playwright screenshot to validate mobile rendering, but the Playwright run timed out and failed.  
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69570a5e974083219c0d6bf4d1736764)