### PR TITLE
Compact permit card rows for faster scanning

### DIFF
--- a/app.js
+++ b/app.js
@@ -580,24 +580,14 @@
       return { validForDays, expirationDate, startDate, actualDays, shortened };
     }
 
-    function getValidityLabels(product) {
+    function getValidityLine(product) {
       if (!product) {
-        return {
-          durationLabel: 'Valid for —',
-          expirationLabel: 'Permit expires —',
-          availableLabel: 'Available until —'
-        };
+        return 'Valid — • Expires —';
       }
 
       const { validForDays, expirationDate, actualDays, shortened } = calculatePermitValidity(product);
       const durationDays = shortened ? actualDays : validForDays;
-      const durationLabel = `Valid for ${durationDays} day${durationDays === 1 ? '' : 's'}`;
-      const expirationLabel = `Permit expires ${formatDate(expirationDate)}`;
-      const availableLabel = product.availableUntil
-        ? `Available until ${formatDate(product.availableUntil)}`
-        : 'Availability varies';
-
-      return { durationLabel, expirationLabel, availableLabel };
+      return `Valid ${durationDays} day${durationDays === 1 ? '' : 's'} • Expires ${formatDate(expirationDate)}`;
     }
 
     const DOCS_BY_PRODUCT_TYPE = {
@@ -648,19 +638,10 @@
       const summaryTitle = document.createElement('span');
       summaryTitle.className = 'docs-title';
       summaryTitle.textContent = 'Maps & permit rules';
-      const summaryMeta = document.createElement('span');
-      summaryMeta.className = 'docs-meta';
-      summaryMeta.textContent = `${docs.length} item${docs.length === 1 ? '' : 's'}`;
       const summaryText = document.createElement('span');
       summaryText.className = 'docs-text';
       summaryText.appendChild(summaryTitle);
-      summaryText.appendChild(summaryMeta);
-      const chevron = document.createElement('span');
-      chevron.className = 'docs-chev';
-      chevron.setAttribute('aria-hidden', 'true');
-      chevron.textContent = '▾';
       summary.appendChild(summaryText);
-      summary.appendChild(chevron);
       details.appendChild(summary);
 
       const docsWrap = document.createElement('div');
@@ -918,9 +899,8 @@
     function createProductCard(p, idx) {
       const id = `prod_${idx}`;
       const priceLine = feeLabelForUnit(p.price, p.unit);
-      const { durationLabel, expirationLabel, availableLabel } = getValidityLabels(p);
+      const validityLine = getValidityLine(p);
       const docs = buildRequiredDocs(p);
-      const officeName = getSelectedOffice()?.name || '—';
 
       const card = document.createElement('label');
       card.className = 'prod';
@@ -944,11 +924,7 @@
       const name = document.createElement('div');
       name.className = 'name';
       name.textContent = p.name;
-      const area = document.createElement('div');
-      area.className = 'area';
-      area.textContent = `District: ${officeName}`;
       info.appendChild(name);
-      info.appendChild(area);
       headerLeft.appendChild(info);
       const price = document.createElement('div');
       price.className = 'price';
@@ -956,22 +932,13 @@
       header.appendChild(headerLeft);
       header.appendChild(price);
 
-      const stats = document.createElement('ul');
-      stats.className = 'stats';
-      stats.setAttribute('aria-label', 'Permit details');
-      [durationLabel, expirationLabel].forEach((label) => {
-        const item = document.createElement('li');
-        item.textContent = label;
-        stats.appendChild(item);
-      });
-
-      const available = document.createElement('div');
-      available.className = 'meta';
-      available.textContent = availableLabel;
+      const validity = document.createElement('div');
+      validity.className = 'validity';
+      validity.textContent = validityLine;
 
       const docsDiv = buildDocLinks(docs);
 
-      [header, stats, available, docsDiv].forEach((node) => body.appendChild(node));
+      [header, validity, docsDiv].forEach((node) => body.appendChild(node));
       card.appendChild(body);
 
       card.querySelector('input').addEventListener('change', () => {

--- a/styles.css
+++ b/styles.css
@@ -226,7 +226,7 @@ body{
     .prod{
       border:1px solid rgba(29,107,66,.18);
       border-radius:var(--radius-card);
-      padding:14px;
+      padding:12px;
       background:#fff;
       display:block;
       transition: border-color var(--motion-fast) var(--motion-ease), box-shadow var(--motion-fast) var(--motion-ease), transform var(--motion-fast) var(--motion-ease);
@@ -255,17 +255,14 @@ body{
       border-color: rgba(29,107,66,.65);
       box-shadow:0 0 0 3px rgba(37,111,176,.28), var(--shadow-md);
     }
-    .prod-body{display:grid; gap:12px}
-    .prod-header{display:flex; justify-content:space-between; gap:16px; align-items:flex-start;}
-    .prod-header-left{display:flex; gap:12px; align-items:flex-start; min-width:0;}
+    .prod-body{display:grid; gap:6px}
+    .prod-header{display:flex; justify-content:space-between; gap:12px; align-items:center;}
+    .prod-header-left{display:flex; gap:10px; align-items:center; min-width:0;}
     .prod-info{display:grid; gap:4px; min-width:0;}
-    .prod-radio{margin-top:3px; width:18px; height:18px; accent-color: var(--brand);}
+    .prod-radio{margin-top:0; width:18px; height:18px; accent-color: var(--brand);}
     .prod .name{font-weight:800; font-size:16px; line-height:1.25}
     .prod .price{font-weight:800; font-size:16px; color:var(--ink); white-space:nowrap}
-    .prod .area{font-size:13px; color:var(--muted);}
-    .stats{list-style:none; display:flex; flex-wrap:wrap; gap:6px; margin:0; padding:0}
-    .stats li{font-size:12.5px; color:var(--ink); padding:4px 8px; border-radius:var(--radius-chip); border:0; background:rgba(29,107,66,.08); font-weight:600;}
-    .prod .meta{color:var(--muted); font-size:12.5px; margin-top:-2px}
+    .prod .validity{font-size:12.5px; color:var(--muted);}
     .prod .docs{
       margin-top:2px;
       border:0;
@@ -275,29 +272,27 @@ body{
       box-shadow:none;
     }
     .prod .docs summary{
-      font-weight:700;
-      font-size:13.5px;
-      color:var(--ink);
+      font-weight:600;
+      font-size:12.5px;
+      color:var(--link);
       cursor:pointer;
       display:flex;
       align-items:center;
       justify-content:space-between;
       gap:10px;
-      border:1px solid var(--color-border);
-      background:#fff;
-      border-radius:var(--radius-input);
-      padding:10px 12px;
+      border:0;
+      background:transparent;
+      border-radius:6px;
+      padding:2px 0;
       width:100%;
+      text-decoration:underline;
+      text-underline-offset:2px;
     }
     .prod .docs summary::-webkit-details-marker{display:none;}
     .docs-text{display:flex; align-items:center; gap:6px;}
-    .docs-chev{font-size:14px; transition:transform var(--motion-fast) var(--motion-ease);}
-    details[open] .docs-chev{transform:rotate(180deg);}
-    .prod .docs summary .docs-meta{font-weight:600;}
     .prod .docs summary:focus-visible{outline:3px solid rgba(37,111,176,.35); outline-offset:3px}
-    .prod .docs summary:hover{background:rgba(29,107,66,.08); border-radius:10px}
-    .docs-title{font-size:13.5px}
-    .docs-meta{font-size:11.5px; color:var(--muted); font-weight:600; text-transform:uppercase; letter-spacing:.02em; margin-left:6px}
+    .prod .docs summary:hover{color:var(--link-hover);}
+    .docs-title{font-size:12.5px}
     .doc-links{
       display:flex;
       flex-wrap:wrap;


### PR DESCRIPTION
### Motivation
- Make each permit card a single compact row so users can scan 4–6 permits per screen instead of 1–2.  
- Remove the redundant district line from each card and replace multiple chip-style detail items with one concise validity line.  
- Keep the Maps & permit rules control accessible but visually lightweight as a small link-like control.  
- Tighten spacing and alignment to reduce card height and visual noise.

### Description
- Replaced `getValidityLabels` with `getValidityLine` in `app.js` and render a single `div.validity` containing text like `Valid 30 days • Expires Jan 31, 2026`.  
- Removed the district/area element from product cards and collapsed the header to a single row containing the radio, title, and price.  
- Simplified the documents summary by removing the item count and chevron and making the `Maps & permit rules` summary a compact, link-styled control.  
- Updated `styles.css` to reduce padding, tighten gaps (`.prod-body`, `.prod-header`, `.prod-header-left`), align the radio vertically, add `.validity` styling, and restyle the docs summary to be underline/link-like.

### Testing
- Started a local dev server with `python -m http.server 8000` and attempted to capture a visual screenshot with Playwright.  
- Playwright failed to launch the headless browser (process crashed with SIGSEGV), so automated visual verification did not complete.  
- No unit tests were executed as part of this change.  
- The changes were committed to the branch (`app.js`, `styles.css`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69570c641be08321aa83ad7d24c27105)